### PR TITLE
Fix documentation of outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ files to S3:
 
 ### Outputs
 
-- `output`: Object of the PutObjectCommand Output, see <https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/PutObjectCommand>
+- `putObjectCommandOutput`: Object of the PutObjectCommand Output, see <https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/PutObjectCommand>

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ inputs:
     required: false
 
 outputs:
-  output:
+  putObjectCommandOutput:
     description: Result of the upload, see PutObjectCommand Output on https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/PutObjectCommand
 
 runs:


### PR DESCRIPTION
Per main.ts, the output is set to the key `putObjectCommandOutput`. This updates the action documentation to reflect that.